### PR TITLE
Add repo-wide status message, clickable to bring up commit info

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The standard installation works with Debian based systems, for other check the i
 - [FreeBSD](https://github.com/Andr3as/Codiad-CodeGit/wiki/FreeBSD-installation)
 
 ### Disable
-To disable the repo-wide status setting, set the parameter `codiad.plugin.codegit.disable` to `"true"`. If you just wish to disable the header bar, set the parameter `codiad.plugin.codegit.disableHeader` to `"true"`.
+To disable the repo-wide status setting, set the parameter `codiad.plugin.codegit.disableRepoStatus` to `"true"`. If you just wish to disable the header bar, set the parameter `codiad.plugin.codegit.disableHeader` to `"true"`.
 
 ##Problems?
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ The standard installation works with Debian based systems, for other check the i
 
 - [FreeBSD](https://github.com/Andr3as/Codiad-CodeGit/wiki/FreeBSD-installation)
 
+### Disable
+To disable the repo-wide status setting, set the parameter `codiad.plugin.codegit.disable` to `"true"`. If you just wish to disable the header bar, set the parameter `codiad.plugin.codegit.disableHeader` to `"true"`.
+
 ##Problems?
 
 Check the [wiki](https://github.com/Andr3as/Codiad-CodeGit/wiki) or open an issue.

--- a/dialog.php
+++ b/dialog.php
@@ -52,6 +52,9 @@
             case 'settings':
                 include('templates/settings.html');
                 break;
+            case 'generalSettings':
+                include('templates/generalSettings.php');
+                break;
             default:
                 echo "No page defined!";
                 break;

--- a/init.js
+++ b/init.js
@@ -48,21 +48,6 @@
                     }
                     
 
-                  //Check if directories has git repo
-                  if ($('#project-root').hasClass('repo') && _this.isEnabledRepoStatus()) {
-                    // add a poller
-                    _this._poller = setInterval(function(){
-                        _this.repostat();
-                    }, 10000);
-                    _this.addStatusIcon();
-                    // only show stat-wrapper if not configured
-                    _this.isEnabledWrapper() && $("#git-repo-stat-wrapper").show();
-                    $("#git-repo-status-icon").show();
-                    _this.repostat();
-                  } else {
-                    $("#git-repo-stat-wrapper").hide();
-                    $("#git-repo-status-icon").hide();
-                  }
                 },0);
             });
             //Handle context-menu
@@ -113,7 +98,7 @@
             amplify.subscribe('active.onSave', function(path){
                 setTimeout(function(){
                     _this.numstat(path);
-		                _this.repostat();
+                    _this.repostat();
                 }, 50);
             });
             amplify.subscribe('active.onClose', function(path){
@@ -126,6 +111,7 @@
             });
             amplify.subscribe('settings.changed', function(){
               //React here on changed settings
+              _this.showRepoStatus();
             });
             //Live features
             $('.git_area #check_all').live("click", function(e){
@@ -172,7 +158,29 @@
                 _this.checkout(_this.files[0], _this.location);
                 _this.showDialog('overview', _this.location);
             });
+            
+            _this.showRepoStatus();
         },
+
+        //Check if directories has git repo
+        showRepoStatus: function () {
+          var _this = this;
+          if ($('#project-root').hasClass('repo') && _this.isEnabledRepoStatus()) {
+            // add a poller
+            _this._poller = setInterval(function(){
+                _this.repostat();
+            }, 10000);
+            _this.addStatusIcon();
+            // only show stat-wrapper if not configured
+            _this.isEnabledWrapper() && $("#git-repo-stat-wrapper").show();
+            $("#git-repo-status-icon").show();
+            _this.repostat();
+          } else {
+            $("#git-repo-stat-wrapper").hide();
+            $("#git-repo-status-icon").hide();
+          }
+        },
+
         
         showSidebarDialog: function() {
             if (!$('#project-root').hasClass('repo')) {

--- a/init.js
+++ b/init.js
@@ -124,6 +124,9 @@
                 _this.repostat();
                 $('#git-stat').html("");
             });
+            amplify.subscribe('settings.changed', function(){
+              //React here on changed settings
+            });
             //Live features
             $('.git_area #check_all').live("click", function(e){
                 if ($('.git_area #check_all').attr("checked") == "checked") {

--- a/init.js
+++ b/init.js
@@ -49,11 +49,11 @@
 										
 									
                   //Check if directories has git repo
-                  if ($('#project-root').hasClass('repo') && _this.isEnabled()) {
+                  if ($('#project-root').hasClass('repo') && _this.isEnabledRepoStatus()) {
 										// add a poller
 				            _this._poller = setInterval(function(){
 				                _this.repostat();
-				            }, 500);
+				            }, 10000);
 				            _this.addStatusIcon();
 										// only show stat-wrapper if not configured
                     _this.isEnabledWrapper() && $("#git-repo-stat-wrapper").show();
@@ -737,25 +737,27 @@
         setBranch: function(branch) {
             $('.git_area .branch').text(branch);
         },
-				addStatusIcon: function () {
-					if ($("span#git-repo-status-icon").length < 1) {
-		        $('#file-manager #project-root').before('<span id="git-repo-status-icon" class="hidden uncommit"></span>');
-					}
-				},
-				
-				isEnabled: function () {
-					var setting = localStorage.getItem('codiad.plugin.codegit.disable'), ret = true;
+
+        addStatusIcon: function () {
+          if ($("span#git-repo-status-icon").length < 1) {
+            $('#file-manager #project-root').before('<span id="git-repo-status-icon" class="hidden uncommit"></span>');
+          }
+        },
+
+        isEnabledRepoStatus: function () {
+          var setting = localStorage.getItem('codiad.plugin.codegit.disableRepoStatus'), ret = true;
           if (setting === "true") {
               ret = false;
           }
-					return(ret);
-				},
-				isEnabledWrapper: function () {
-					var setting = localStorage.getItem('codiad.plugin.codegit.disableHeader'), ret = true;
+          return(ret);
+        },
+
+        isEnabledWrapper: function () {
+          var setting = localStorage.getItem('codiad.plugin.codegit.disableHeader'), ret = true;
           if (setting === "true") {
               ret = false;
           }
-					return(ret);
-				}
+          return(ret);
+        }
     };
 })(this, jQuery);

--- a/init.js
+++ b/init.js
@@ -41,21 +41,21 @@
                         }
                     });
 
-										// clear an old poller
-										if (_this._poller) {
-					            clearInterval(_this._poller);
-											delete _this._poller;
-										}
-										
-									
+                    // clear an old poller
+                    if (_this._poller) {
+                      clearInterval(_this._poller);
+                      delete _this._poller;
+                    }
+                    
+
                   //Check if directories has git repo
                   if ($('#project-root').hasClass('repo') && _this.isEnabledRepoStatus()) {
-										// add a poller
-				            _this._poller = setInterval(function(){
-				                _this.repostat();
-				            }, 10000);
-				            _this.addStatusIcon();
-										// only show stat-wrapper if not configured
+                    // add a poller
+                    _this._poller = setInterval(function(){
+                        _this.repostat();
+                    }, 10000);
+                    _this.addStatusIcon();
+                    // only show stat-wrapper if not configured
                     _this.isEnabledWrapper() && $("#git-repo-stat-wrapper").show();
                     $("#git-repo-status-icon").show();
                     _this.repostat();

--- a/init.js
+++ b/init.js
@@ -41,6 +41,8 @@
                         }
                     });
 
+                    _this.showRepoStatus();
+
                     // clear an old poller
                     if (_this._poller) {
                       clearInterval(_this._poller);
@@ -158,8 +160,6 @@
                 _this.checkout(_this.files[0], _this.location);
                 _this.showDialog('overview', _this.location);
             });
-            
-            _this.showRepoStatus();
         },
 
         //Check if directories has git repo
@@ -172,7 +172,11 @@
             }, 10000);
             _this.addStatusIcon();
             // only show stat-wrapper if not configured
-            _this.isEnabledWrapper() && $("#git-repo-stat-wrapper").show();
+            if (_this.isEnabledWrapper()) {
+              $("#git-repo-stat-wrapper").show();
+            } else {
+              $("#git-repo-stat-wrapper").hide();
+            }
             $("#git-repo-status-icon").show();
             _this.repostat();
           } else {

--- a/init.js
+++ b/init.js
@@ -40,13 +40,29 @@
                             });
                         }
                     });
-                    //Check if directories has git repo
-                    if ($('#project-root').hasClass('repo')) {
-                      $("#git-repo-stat-wrapper").show();
-	                    _this.repostat();
-                    } else {
-                      $("#git-repo-stat-wrapper").hide();
-                    }
+
+										// clear an old poller
+										if (_this._poller) {
+					            clearInterval(_this._poller);
+											delete _this._poller;
+										}
+										
+									
+                  //Check if directories has git repo
+                  if ($('#project-root').hasClass('repo') && _this.isEnabled()) {
+										// add a poller
+				            _this._poller = setInterval(function(){
+				                _this.repostat();
+				            }, 500);
+				            _this.addStatusIcon();
+										// only show stat-wrapper if not configured
+                    _this.isEnabledWrapper() && $("#git-repo-stat-wrapper").show();
+                    $("#git-repo-status-icon").show();
+                    _this.repostat();
+                  } else {
+                    $("#git-repo-stat-wrapper").hide();
+                    $("#git-repo-status-icon").hide();
+                  }
                 },0);
             });
             //Handle context-menu
@@ -81,8 +97,9 @@
             amplify.subscribe("context-menu.onHide", function(){
                 $('.code_git').remove();
             });
-            //repo stats
+            //repo status
             $('#file-manager').before('<div id="git-repo-stat-wrapper" class="hidden">Commit Status: <span id="git-repo-stat"></span></div>');
+            _this.addStatusIcon();
             // clicking on it brings up the commit box
             $("#git-repo-stat-wrapper").click(function(){
               codiad.CodeGit.showDialog('overview', codiad.project.getCurrent());
@@ -646,6 +663,9 @@
                 $('#git-repo-stat').html(insert);
                 $('#git-repo-stat-wrapper').removeClass("git-repo-stat-valid git-repo-stat-invalid git-repo-stat-untracked")
                    .addClass("git-repo-stat-"+cls);
+                // show the icon
+                $("#git-repo-status-icon").removeClass("git-repo-icon-valid git-repo-icon-invalid git-repo-icon-untracked")
+                   .addClass("git-repo-icon-"+cls);
             });
         },
         
@@ -716,6 +736,26 @@
         
         setBranch: function(branch) {
             $('.git_area .branch').text(branch);
-        }
+        },
+				addStatusIcon: function () {
+					if ($("span#git-repo-status-icon").length < 1) {
+		        $('#file-manager #project-root').before('<span id="git-repo-status-icon" class="hidden uncommit"></span>');
+					}
+				},
+				
+				isEnabled: function () {
+					var setting = localStorage.getItem('codiad.plugin.codegit.disable'), ret = true;
+          if (setting === "true") {
+              ret = false;
+          }
+					return(ret);
+				},
+				isEnabledWrapper: function () {
+					var setting = localStorage.getItem('codiad.plugin.codegit.disableHeader'), ret = true;
+          if (setting === "true") {
+              ret = false;
+          }
+					return(ret);
+				}
     };
 })(this, jQuery);

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 [{ "author" : "Andr3as",
-    "version": "0.5.8",
+    "version": "0.5.9",
     "name" : "CodeGit",
     "url" : "https://github.com/Andr3as/Codiad-CodeGit",
     "rightbar": [

--- a/plugin.json
+++ b/plugin.json
@@ -8,5 +8,10 @@
             "icon": "icon-flow-branch",
             "title": "CodeGit"
         }
-    ]
+    ],
+    "config": [{
+            "file": "dialog.php?action=generalSettings",
+            "icon": "icon-flow-branch",
+            "title": "CodeGit"
+    }]
 }]

--- a/screen.css
+++ b/screen.css
@@ -111,3 +111,22 @@
     float: left;
 }
 
+#git-repo-stat-wrapper {
+	margin: 5px 0px 0px 0px;
+	padding: 2px 10px 2px 10px;
+	cursor: pointer;
+}
+
+.git-repo-stat-valid {
+	background-color: green;
+}
+.git-repo-stat-invalid {
+	background-color: red;
+}
+.git-repo-stat-untracked {
+	background-color: blue;
+}
+
+.hidden {
+	display: none;
+}

--- a/screen.css
+++ b/screen.css
@@ -126,7 +126,25 @@
 .git-repo-stat-untracked {
 	background-color: blue;
 }
+.git-repo-icon-valid {
+	color: green;
+}
+.git-repo-icon-invalid {
+	color: red;
+}
+.git-repo-icon-untracked {
+	color: blue;
+}
 
 .hidden {
 	display: none;
+}
+
+#file-manager span.uncommit:before {
+	content: "\25cf";
+  font-size: 1.9em;
+}
+#file-manager span.uncommit {
+	float: left;
+	padding-top: 8px;
 }

--- a/templates/generalSettings.php
+++ b/templates/generalSettings.php
@@ -1,0 +1,31 @@
+<?php
+    require_once('../../common.php');
+?>
+<div class="codegit_settings">
+    <label><span class="icon-flow-branch big-icon"></span>CodeGit Settings</label>
+    <hr>
+    <table class="settings">
+        <tr>
+            <td style="width: 80%;">
+                Disable repo-wide status
+            </td>
+            <td>
+                <select class="setting" data-setting="codiad.plugin.codegit.disable">
+                    <option value="true"><?php i18n("Yes"); ?></option>
+                    <option value="false" selected><?php i18n("No"); ?></option>
+                </select>
+            </td>
+        </tr>
+        <tr>
+            <td style="width: 80%;">
+                Disable repo-wide status header
+            </td>
+            <td>
+                <select class="setting" data-setting="codiad.plugin.codegit.disableHeader">
+                    <option value="true"><?php i18n("Yes"); ?></option>
+                    <option value="false" selected><?php i18n("No"); ?></option>
+                </select>
+            </td>
+        </tr>
+    </table>
+</div>

--- a/templates/generalSettings.php
+++ b/templates/generalSettings.php
@@ -10,7 +10,7 @@
                 Disable repo-wide status
             </td>
             <td>
-                <select class="setting" data-setting="codiad.plugin.codegit.disable">
+                <select class="setting" data-setting="codiad.plugin.codegit.disableRepoStatus">
                     <option value="true"><?php i18n("Yes"); ?></option>
                     <option value="false" selected><?php i18n("No"); ?></option>
                 </select>


### PR DESCRIPTION
This creates a colour-coded and text-filled line at the top of the project file explorer if the root is a git repo. 

The statuses are:

* Committed (green): all changes have been committed
* Uncommitted (red): one or more changes - add, modify, delete, rename - has been saved but not committed
* Untracked (blue): no uncommitted files exist, but one or more files is untracked

The status line is clickable, bringing up the CodeGit window.